### PR TITLE
ejt3820 bio -add

### DIFF
--- a/bios/githubteacher.md
+++ b/bios/githubteacher.md
@@ -5,3 +5,5 @@
 **Occupation:** Teacher
 
 **Location:** Boise
+
+**Email** tedt@fakedomain.com

--- a/bios/githubteacher.md
+++ b/bios/githubteacher.md
@@ -1,0 +1,7 @@
+## Ted T
+
+**Name:** Ted Thomas
+
+**Occupation:** Teacher
+
+**Location:** Boise


### PR DESCRIPTION
This pull request adds a bio for ejt3820, mislabelled as githubteacher.as requested in #30.

@Hutchasmuch, do you concur?
